### PR TITLE
Throwing SocketException when Client connection is closed and not attempting a retry.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.3.4
+=====
+* Fixed a connection issue in the Client when running on mono
+
 0.3.3
 =====
 * using log4net logger directly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.3.3.{build}
+version: 0.3.4.{build}
 configuration: Release
 platform: Any CPU
 

--- a/src/MindTouch.Clacks.Client/ClacksClient.cs
+++ b/src/MindTouch.Clacks.Client/ClacksClient.cs
@@ -84,12 +84,13 @@ namespace MindTouch.Clacks.Client {
         public Response Exec(Request request) {
             ThrowIfDisposed();
             var isReconnect = !_attemptReconnect;
+            var retry = !isReconnect;
             while(true) {
                 InitSocket();
                 try {
-                    _socket.SendRequest(request);
+                    _socket.SendRequest(request, retry);
                     _receiver.Reset(request);
-                    return _receiver.GetResponse();
+                    return _receiver.GetResponse(retry);
                 } catch(SocketException) {
                     DisposeSocket();
                     if(isReconnect) {
@@ -113,14 +114,15 @@ namespace MindTouch.Clacks.Client {
             }
             ThrowIfDisposed();
             var isReconnect = !_attemptReconnect;
+            var retry = !isReconnect;
             while(true) {
                 InitSocket();
                 try {
-                    _socket.SendRequest(request);
+                    _socket.SendRequest(request, retry);
                     _receiver.Reset(request);
                     var responses = new List<Response>();
                     while(true) {
-                        var response = _receiver.GetResponse();
+                        var response = _receiver.GetResponse(retry);
                         if(!requestInfo.IsExpected(response.Status)) {
                             return new[] { response };
                         }

--- a/src/MindTouch.Clacks.Client/Extensions.cs
+++ b/src/MindTouch.Clacks.Client/Extensions.cs
@@ -27,15 +27,15 @@ namespace MindTouch.Clacks.Client {
             stream.Write(buffer, 0, buffer.Length);
         }
 
-        public static void SendRequest(this ISocket socket, IRequestInfo request) {
+        public static void SendRequest(this ISocket socket, IRequestInfo request, bool retry) {
             var bytes = request.AsBytes();
-            socket.SendBuffer(bytes, bytes.Length);
+            socket.SendBuffer(bytes, bytes.Length, retry);
         }
 
-        private static void SendBuffer(this ISocket socket, byte[] buffer, int count) {
+        private static void SendBuffer(this ISocket socket, byte[] buffer, int count, bool retry) {
             var offset = 0;
             while(count > 0) {
-                var sent = socket.Send(buffer, offset, count);
+                var sent = socket.Send(buffer, offset, count, retry);
                 offset += sent;
                 count -= sent;
             }

--- a/src/MindTouch.Clacks.Client/Net/Helper/PoolSocket.cs
+++ b/src/MindTouch.Clacks.Client/Net/Helper/PoolSocket.cs
@@ -42,34 +42,35 @@ namespace MindTouch.Clacks.Client.Net.Helper {
             _reclaim(_socket);
         }
 
-        public int Send(byte[] buffer, int offset, int size) {
-            return Try(() => _socket.Send(buffer, offset, size));
+        public int Send(byte[] buffer, int offset, int size, bool retry) {
+            return Try(() => _socket.Send(buffer, offset, size, retry), retry);
         }
 
-        public int Receive(byte[] buffer, int offset, int size) {
-            return Try(() => _socket.Receive(buffer, offset, size));
+        public int Receive(byte[] buffer, int offset, int size, bool retry) {
+            return Try(() => _socket.Receive(buffer, offset, size, retry), retry);
         }
 
-        private T Try<T>(Func<T> func, bool retry = true) {
+        private T Try<T>(Func<T> func, bool retry) {
             if(_disposed) {
                 throw new ObjectDisposedException("PoolSocket");
             }
-            try {
-                return func();
-            } catch(ObjectDisposedException) {
+            if(Connected || retry) {
                 try {
-                    Dispose();
-                } catch { }
-                throw;
-
-            } catch(SocketException) {
-                try {
-                    _socket.Dispose();
-                    Dispose();
-                } catch { }
-                throw;
-
+                    return func();
+                } catch (ObjectDisposedException) {
+                    try {
+                        Dispose();
+                    } catch { }
+                    throw;
+                } catch (SocketException) {
+                    try {
+                        _socket.Dispose();
+                        Dispose();
+                    } catch { }
+                    throw;
+                }
             }
+            throw new SocketException((int)SocketError.NotConnected);
         }
     }
 }

--- a/src/MindTouch.Clacks.Client/Net/Helper/SocketAdapter.cs
+++ b/src/MindTouch.Clacks.Client/Net/Helper/SocketAdapter.cs
@@ -95,11 +95,11 @@ namespace MindTouch.Clacks.Client.Net.Helper {
             _isDisposed = true;
         }
 
-        public int Send(byte[] buffer, int offset, int size) {
+        public int Send(byte[] buffer, int offset, int size, bool retry) {
             return _socket.Send(buffer, offset, size, SocketFlags.None);
         }
 
-        public int Receive(byte[] buffer, int offset, int size) {
+        public int Receive(byte[] buffer, int offset, int size, bool retry) {
             return _socket.Receive(buffer, offset, size, SocketFlags.None);
         }
     }

--- a/src/MindTouch.Clacks.Client/Net/ISocket.cs
+++ b/src/MindTouch.Clacks.Client/Net/ISocket.cs
@@ -23,7 +23,7 @@ namespace MindTouch.Clacks.Client.Net {
     public interface ISocket : IDisposable {
         bool Connected { get; }
         bool IsDisposed { get; }
-        int Send(byte[] buffer, int offset, int size);
-        int Receive(byte[] buffer, int offset, int size);
+        int Send(byte[] buffer, int offset, int size, bool retry);
+        int Receive(byte[] buffer, int offset, int size, bool retry);
     }
 }

--- a/src/test/MindTouch.Clacks.Client.Tests/FakeSocket.cs
+++ b/src/test/MindTouch.Clacks.Client.Tests/FakeSocket.cs
@@ -51,13 +51,13 @@ namespace MindTouch.Clacks.Client.Tests {
         public Func<byte[], int, int, int> ReceiveCallback = (buffer, offset, size) => 0;
         public int ReceiveCalled;
 
-        public int Send(byte[] buffer, int offset, int size) {
+        public int Send(byte[] buffer, int offset, int size, bool retry) {
             SendCalled++;
             SendCallback();
             return size;
         }
 
-        public int Receive(byte[] buffer, int offset, int size) {
+        public int Receive(byte[] buffer, int offset, int size, bool retry) {
             ReceiveCalled++;
             return ReceiveCallback(buffer, offset, size);
         }

--- a/src/test/MindTouch.Clacks.Client.Tests/ResponseReceiverTests.cs
+++ b/src/test/MindTouch.Clacks.Client.Tests/ResponseReceiverTests.cs
@@ -45,7 +45,7 @@ namespace MindTouch.Clacks.Client.Tests {
             // Act
             var receiver = new ResponseReceiver(fakeSocket);
             receiver.Reset(new Request("OK").ExpectData("OK"));
-            var response = receiver.GetResponse();
+            var response = receiver.GetResponse(false);
             Assert.AreEqual("OK", response.Status);
 
             // Assert
@@ -68,7 +68,7 @@ namespace MindTouch.Clacks.Client.Tests {
             // Act
             var receiver = new ResponseReceiver(fakeSocket);
             receiver.Reset(new Request("OK").ExpectData("OK"));
-            var response = receiver.GetResponse();
+            var response = receiver.GetResponse(false);
             Assert.AreEqual("OK", response.Status);
 
             // Assert
@@ -92,7 +92,7 @@ namespace MindTouch.Clacks.Client.Tests {
             // Act
             var receiver = new ResponseReceiver(fakeSocket);
             receiver.Reset(new Request("OK").ExpectData("OK"));
-            var response = receiver.GetResponse();
+            var response = receiver.GetResponse(false);
             Assert.AreEqual("OK", response.Status);
 
             // Assert
@@ -118,7 +118,7 @@ namespace MindTouch.Clacks.Client.Tests {
             // Act
             var receiver = new ResponseReceiver(fakeSocket);
             receiver.Reset(new Request("OK").ExpectData("OK"));
-            var response = receiver.GetResponse();
+            var response = receiver.GetResponse(false);
             Assert.AreEqual("OK", response.Status);
 
             // Assert

--- a/src/test/MindTouch.Clacks.Client.Tests/SocketAdapterTests.cs
+++ b/src/test/MindTouch.Clacks.Client.Tests/SocketAdapterTests.cs
@@ -117,7 +117,7 @@ namespace MindTouch.Clacks.Client.Tests {
                 // Act
                 try {
                     var buffer = new byte[4096];
-                    socket.Receive(buffer, 0, 10);
+                    socket.Receive(buffer, 0, 10, false);
                 } catch(SocketException) {
                     return;
                 }

--- a/src/test/MindTouch.Clacks.Server.Tests/ErrorHandlingTests.cs
+++ b/src/test/MindTouch.Clacks.Server.Tests/ErrorHandlingTests.cs
@@ -100,10 +100,10 @@ namespace MindTouch.Clacks.Server.Tests {
 
                     var socket = SocketAdapter.Open(_endpoint);
                     var request = Encoding.ASCII.GetBytes("HELLO 4\r\n0123456789\r\n");
-                    socket.Send(request, 0, request.Length);
+                    socket.Send(request, 0, request.Length, false);
                     var response = new byte[1024];
                     try {
-                        var read = socket.Receive(response, 0, 1024);
+                        var read = socket.Receive(response, 0, 1024, false);
                     } catch { }
                 }
             }


### PR DESCRIPTION
Due to an implementation different of the System.Net.Socket class between Mono and .NET

Reviewed by @manuel-sugawara
