### PR TITLE
Close socket once it is no longer connected. 

### DIFF
--- a/src/MindTouch.Clacks.Client/Net/Helper/PoolSocket.cs
+++ b/src/MindTouch.Clacks.Client/Net/Helper/PoolSocket.cs
@@ -55,7 +55,10 @@ namespace MindTouch.Clacks.Client.Net.Helper {
                 throw new ObjectDisposedException("PoolSocket");
             }
             if(!Connected) {
-                //throw new ConnectException();
+                try {
+                    _socket.Dispose();
+                    Dispose();
+                } catch { }
                 throw new SocketException((int)SocketError.NotConnected);
             }
             try {


### PR DESCRIPTION
https://mindtouch.myjetbrains.com/youtrack/issue/MT-22980
reviewed by @coreycoto & @PeteE 

When we detect that a socket is disconnected, we previously Disposed the PoolSocket only, but not the underlying Socket, which was then put back into the ConnectionPool. By disposing of it immediately, we force the ConnectionPool to give us back a fresh socket.
